### PR TITLE
format the output-filename on template_gen.py

### DIFF
--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -403,7 +403,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
             for template in temp_list:
                 template.write(
                     "eqcorrscan_temporary_templates{0}{1}.ms".format(
-                        os.path.sep, template[0].stats.starttime),
+                        os.path.sep, template[0].stats.starttime.strftime("%Y-%m-%dT%H%M%S")),
                     format="MSEED")
         del st
     if return_event:
@@ -828,11 +828,11 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
         tplot(st1, background=stplot, picks=picks_copy,
               title='Template for ' + str(st1[0].stats.starttime),
               savefile="{0}/{1}_template.png".format(
-                  plotdir, st1[0].stats.starttime),
+                  plotdir, st1[0].stats.starttime.strftime("%Y-%m-%dT%H%M%S")),
               **plot_kwargs)
         noise_plot(signal=st1, noise=noise,
                    savefile="{0}/{1}_noise.png".format(
-                       plotdir, st1[0].stats.starttime),
+                       plotdir, st1[0].stats.starttime.strftime("%Y-%m-%dT%H%M%S")),
                    **plot_kwargs)
         del stplot
     return st1


### PR DESCRIPTION
Found an issue when construct template with option plotdir or save_progress on windows10, which can't use special character on the filename. So I added string format "strftime("%Y-%m-%dT%H%M%S")" for the default output-filename.

<!--
Thank your for contributing to EQcorrscan!
Please fill out the sections below.
-->

### What does this PR do?
fix issue in template_gen

### Why was it initiated?  Any relevant Issues?
https://github.com/eqcorrscan/EQcorrscan/issues/344

### PR Checklist
- [ ] `develop` base branch selected?
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGES.md`.
- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.
